### PR TITLE
fix DarkSteel and other EIO items display

### DIFF
--- a/src/main/java/com/caedis/duradisplay/render/DurabilityRenderer.java
+++ b/src/main/java/com/caedis/duradisplay/render/DurabilityRenderer.java
@@ -325,7 +325,7 @@ public class DurabilityRenderer {
         List<ItemStackOverlay> overlays = new ArrayList<>();
 
         if (DuraDisplayConfig.DurabilityConfig.Enabled
-            && !(DuraDisplayConfig.DurabilityConfig.ShowWhenFull && (stack.getItemDamage() < stack.getMaxDamage()))) {
+            && !(DuraDisplayConfig.DurabilityConfig.ShowWhenFull && (stack.getItemDamage() == stack.getMaxDamage()))) {
 
             ItemStackOverlay durabilityOverlay = new ItemStackOverlay.DurabilityOverlay();
             double durability = (1 - item.getDurabilityForDisplay(stack));

--- a/src/main/java/com/caedis/duradisplay/render/DurabilityRenderer.java
+++ b/src/main/java/com/caedis/duradisplay/render/DurabilityRenderer.java
@@ -318,11 +318,25 @@ public class DurabilityRenderer {
 
     // handles all other EIO items
     private static List<ItemStackOverlay> handleDarkSteelItems(@NotNull ItemStack stack) {
+
+        Item item = stack.getItem();
+        assert item != null;
+
         List<ItemStackOverlay> overlays = new ArrayList<>();
-        List<ItemStackOverlay> defaultOverlays = handleDefault(stack);
-        if (defaultOverlays != null) {
-            overlays.addAll(defaultOverlays);
+
+        if (DuraDisplayConfig.DurabilityConfig.Enabled
+            && !(DuraDisplayConfig.DurabilityConfig.ShowWhenFull && (stack.getItemDamage() < stack.getMaxDamage()))) {
+
+            ItemStackOverlay durabilityOverlay = new ItemStackOverlay.DurabilityOverlay();
+            double durability = (1 - item.getDurabilityForDisplay(stack));
+            if (Double.isNaN(durability)) return null;
+            durabilityOverlay.color = getRGBDurabilityForDisplay(durability);
+            durability *= 100;
+            durabilityOverlay.isFull = durability == 100.0;
+            durabilityOverlay.value = nf.format(durability) + "%";
+            overlays.add(durabilityOverlay);
         }
+
         if (!DuraDisplayConfig.ChargeConfig.Enabled || !stack.hasTagCompound()) return overlays;
 
         NBTTagCompound nbt = stack.getTagCompound();


### PR DESCRIPTION
DarkSteel tools and armors implement their `isDamaged()` method as returning a **constant `false`**, causing [`handleDefault`](https://github.com/GTNewHorizons/DuraDisplay/blob/5e0a4a2244d05e422924b1110ab729e8c0bd3ff5/src/main/java/com/caedis/duradisplay/render/DurabilityRenderer.java#L116) to return null on such items when `ShowWhenFull` config set to true.

In order not to add a extra check for `handleDefault`, changes are made inside `handleDarkSteelItems` method.

Other possible, but in my opinion, problematic fixes are there.
1. This can also be fixed on the EIO side, but such a wired **constant `false`** might be intended for other uses which is far beyond my knowing.
2. A simple fix could be changing the `handleDefault` to check item damage by comparing max and current, but other mods might override the `isDamaged` method too to do something else.

As a result this PR might seem more complex then it might should have been.