### PR TITLE
Fix the display of IC2 electric jetpack and some RF items

### DIFF
--- a/src/main/java/com/caedis/duradisplay/render/DurabilityRenderer.java
+++ b/src/main/java/com/caedis/duradisplay/render/DurabilityRenderer.java
@@ -301,8 +301,7 @@ public class DurabilityRenderer {
             overlays.addAll(defaultOverlays);
         }
 
-        if (!DuraDisplayConfig.ChargeConfig.Enabled || !(stack.hasTagCompound() && stack.getTagCompound()
-            .hasKey("Energy"))) return overlays;
+        if (!DuraDisplayConfig.ChargeConfig.Enabled ) return overlays;
         IEnergyContainerItem eci = ((IEnergyContainerItem) stack.getItem());
         assert eci != null;
 

--- a/src/main/java/com/caedis/duradisplay/render/DurabilityRenderer.java
+++ b/src/main/java/com/caedis/duradisplay/render/DurabilityRenderer.java
@@ -53,11 +53,11 @@ public class DurabilityRenderer {
         itemHandlers.put(GT_MetaBase_Item.class, DurabilityRenderer::handleGregTech);
         itemHandlers.put(GT_RadioactiveCell_Item.class, DurabilityRenderer::handleGregTechRadioactiveCell);
         itemHandlers.put(IDarkSteelItem.class, DurabilityRenderer::handleDarkSteelItems);
-        itemHandlers.put(IEnergyContainerItem.class, DurabilityRenderer::handleEnergyContainer);
         itemHandlers.put(AmmoItem.class, (is -> null));
         itemHandlers.put(ToolCore.class, DurabilityRenderer::handleToolCore);
         itemHandlers.put(IElectricItem.class, DurabilityRenderer::handleIElectricItem);
         itemHandlers.put(ItemArmorFluidTank.class, DurabilityRenderer::handleItemArmorFluidTank);
+        itemHandlers.put(IEnergyContainerItem.class, DurabilityRenderer::handleEnergyContainer);
         itemHandlers.put(ICustomDamageItem.class, DurabilityRenderer::handleICustomDamageItem);
         itemHandlers.put(ItemBrewBase.class, DurabilityRenderer::handleBotaniaBrew);
         itemHandlers.put(Item.class, DurabilityRenderer::handleDefault);

--- a/src/main/java/com/caedis/duradisplay/render/DurabilityRenderer.java
+++ b/src/main/java/com/caedis/duradisplay/render/DurabilityRenderer.java
@@ -53,10 +53,10 @@ public class DurabilityRenderer {
         itemHandlers.put(GT_MetaBase_Item.class, DurabilityRenderer::handleGregTech);
         itemHandlers.put(GT_RadioactiveCell_Item.class, DurabilityRenderer::handleGregTechRadioactiveCell);
         itemHandlers.put(IDarkSteelItem.class, DurabilityRenderer::handleDarkSteelItems);
+        itemHandlers.put(IEnergyContainerItem.class, DurabilityRenderer::handleEnergyContainer);
         itemHandlers.put(AmmoItem.class, (is -> null));
         itemHandlers.put(ToolCore.class, DurabilityRenderer::handleToolCore);
         itemHandlers.put(IElectricItem.class, DurabilityRenderer::handleIElectricItem);
-        itemHandlers.put(IEnergyContainerItem.class, DurabilityRenderer::handleEnergyContainer);
         itemHandlers.put(ItemArmorFluidTank.class, DurabilityRenderer::handleItemArmorFluidTank);
         itemHandlers.put(ICustomDamageItem.class, DurabilityRenderer::handleICustomDamageItem);
         itemHandlers.put(ItemBrewBase.class, DurabilityRenderer::handleBotaniaBrew);

--- a/src/main/java/com/caedis/duradisplay/render/DurabilityRenderer.java
+++ b/src/main/java/com/caedis/duradisplay/render/DurabilityRenderer.java
@@ -74,7 +74,7 @@ public class DurabilityRenderer {
             .filter(clazz -> clazz.isInstance(stack.getItem()))
             .findFirst();
 
-        if (!key.isPresent()) return;
+        if (key.isEmpty()) return;
 
         List<ItemStackOverlay> list = itemHandlers.get(key.get())
             .apply(stack);
@@ -230,7 +230,7 @@ public class DurabilityRenderer {
         List<ItemStackOverlay> overlays = new ArrayList<>();
 
         ItemStackOverlay chargeOverlay = new ItemStackOverlay.ChargeOverlay();
-        double charge = ((double) ElectricItem.manager.getCharge(stack) / bei.getMaxCharge(stack)) * 100;
+        double charge = (ElectricItem.manager.getCharge(stack) / bei.getMaxCharge(stack)) * 100;
         if (Double.isNaN(charge)) return null;
         chargeOverlay.isFull = charge == 100.0;
         chargeOverlay.value = nf.format(charge) + "%";
@@ -247,7 +247,7 @@ public class DurabilityRenderer {
         List<ItemStackOverlay> overlays = new ArrayList<>();
 
         ItemStackOverlay overlay = new ItemStackOverlay.DurabilityOverlay();
-        double charge = ((double) bei.getCharge(stack) / bei.getMaxCharge(stack));
+        double charge = (bei.getCharge(stack) / bei.getMaxCharge(stack));
         if (Double.isNaN(charge)) return null;
         overlay.color = getRGBDurabilityForDisplay(charge);
         charge *= 100;
@@ -301,7 +301,7 @@ public class DurabilityRenderer {
             overlays.addAll(defaultOverlays);
         }
 
-        if (!DuraDisplayConfig.ChargeConfig.Enabled ) return overlays;
+        if (!DuraDisplayConfig.ChargeConfig.Enabled) return overlays;
         IEnergyContainerItem eci = ((IEnergyContainerItem) stack.getItem());
         assert eci != null;
 

--- a/src/main/java/com/caedis/duradisplay/render/DurabilityRenderer.java
+++ b/src/main/java/com/caedis/duradisplay/render/DurabilityRenderer.java
@@ -55,10 +55,10 @@ public class DurabilityRenderer {
         itemHandlers.put(IDarkSteelItem.class, DurabilityRenderer::handleDarkSteelItems);
         itemHandlers.put(AmmoItem.class, (is -> null));
         itemHandlers.put(ToolCore.class, DurabilityRenderer::handleToolCore);
-        itemHandlers.put(ItemArmorFluidTank.class, DurabilityRenderer::handleItemArmorFluidTank);
         itemHandlers.put(IElectricItem.class, DurabilityRenderer::handleIElectricItem);
-        itemHandlers.put(ICustomDamageItem.class, DurabilityRenderer::handleICustomDamageItem);
         itemHandlers.put(IEnergyContainerItem.class, DurabilityRenderer::handleEnergyContainer);
+        itemHandlers.put(ItemArmorFluidTank.class, DurabilityRenderer::handleItemArmorFluidTank);
+        itemHandlers.put(ICustomDamageItem.class, DurabilityRenderer::handleICustomDamageItem);
         itemHandlers.put(ItemBrewBase.class, DurabilityRenderer::handleBotaniaBrew);
         itemHandlers.put(Item.class, DurabilityRenderer::handleDefault);
     }

--- a/src/main/java/com/caedis/duradisplay/render/DurabilityRenderer.java
+++ b/src/main/java/com/caedis/duradisplay/render/DurabilityRenderer.java
@@ -74,7 +74,7 @@ public class DurabilityRenderer {
             .filter(clazz -> clazz.isInstance(stack.getItem()))
             .findFirst();
 
-        if (key.isEmpty()) return;
+        if (!key.isPresent()) return;
 
         List<ItemStackOverlay> list = itemHandlers.get(key.get())
             .apply(stack);


### PR DESCRIPTION
1. rearrange the order of handlers to make `IElectricItem` take precedure
2. remove RF NBT tag check as it filters items like eio capacitor banks and BC robots, while doing no good to TiC (handled by a separate function)