### PR TITLE
Limit GT gadgets to metaitem1 (for now?)

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -36,7 +36,7 @@
 dependencies {
     annotationProcessor(project(":processor"))
     compileOnly('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-440-GTNH:dev')
-    compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.49.29:dev')
+    devOnlyNonPublishable('com.github.GTNewHorizons:GT5-Unofficial:5.09.49.29:dev')
     compileOnly("com.github.GTNewHorizons:EnderIO:2.8.17:dev")
     compileOnly("com.github.GTNewHorizons:ae2stuff:0.8.2-GTNH:dev")
     compileOnly("com.github.GTNewHorizons:NewHorizonsCoreMod:2.6.8:dev")

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -35,13 +35,13 @@
  */
 dependencies {
     annotationProcessor(project(":processor"))
-    compileOnly('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-405-GTNH:dev')
-    compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.48.56:dev')
-    compileOnly("com.github.GTNewHorizons:EnderIO:2.8.6:dev")
-    runtimeOnlyNonPublishable("com.github.GTNewHorizons:ae2stuff:0.8.2-GTNH:dev")
-    runtimeOnlyNonPublishable("com.github.GTNewHorizons:NewHorizonsCoreMod:2.5.16:dev")
+    compileOnly('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-440-GTNH:dev')
+    compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.49.29:dev')
+    compileOnly("com.github.GTNewHorizons:EnderIO:2.8.17:dev")
+    compileOnly("com.github.GTNewHorizons:ae2stuff:0.8.2-GTNH:dev")
+    compileOnly("com.github.GTNewHorizons:NewHorizonsCoreMod:2.6.8:dev")
     compileOnly("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")
-    compileOnly("com.github.GTNewHorizons:Botania:1.11.3-GTNH:dev")
-    compileOnly("com.github.GTNewHorizons:TinkersConstruct:1.12.4-GTNH:dev")
+    compileOnly("com.github.GTNewHorizons:Botania:1.11.5-GTNH:dev")
+    compileOnly("com.github.GTNewHorizons:TinkersConstruct:1.12.8-GTNH:dev")
     compileOnly("com.github.GTNewHorizons:TinkersMechworks:0.3.1:dev")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -76,6 +76,11 @@ accessTransformersFile =
 # Provides setup for Mixins if enabled. If you don't know what mixins are: Keep it disabled!
 usesMixins = true
 
+# Set to a non-empty string to configure mixins in a separate source set under src/VALUE, instead of src/main.
+# This can speed up compile times thanks to not running the mixin annotation processor on all input sources.
+# Mixin classes will have access to "main" classes, but not the other way around.
+separateMixinSourceSet =
+
 # Adds some debug arguments like verbose output and class export.
 usesMixinDebug = false
 
@@ -108,8 +113,14 @@ minimizeShadowedDependencies = true
 # If disabled, won't rename the shadowed classes.
 relocateShadowedDependencies = true
 
-# Adds the GTNH maven, CurseMaven, Modrinth, and some more well-known 1.7.10 repositories.
+# Adds CurseMaven, Modrinth, and some more well-known 1.7.10 repositories.
 includeWellKnownRepositories = true
+
+# A list of repositories to exclude from the includeWellKnownRepositories setting. Should be a space separated
+# list of strings, with the acceptable keys being(case does not matter):
+# cursemaven
+# modrinth
+excludeWellKnownRepositories =
 
 # Change these to your Maven coordinates if you want to publish to a custom Maven repository instead of the default GTNH Maven.
 # Authenticate with the MAVEN_USER and MAVEN_PASSWORD environment variables.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,7 +16,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.23'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.26'
 }
 
 

--- a/src/main/java/com/caedis/duradisplay/overlay/OverlayGadgets.java
+++ b/src/main/java/com/caedis/duradisplay/overlay/OverlayGadgets.java
@@ -14,6 +14,8 @@ import com.caedis.duradisplay.utils.DurabilityFormatter;
 import com.caedis.duradisplay.utils.DurabilityLikeInfo;
 import com.google.common.collect.Sets;
 
+import gregtech.common.items.GT_MetaGenerated_Item_01;
+
 // Gadgets are items to show UseCount(remain) as default
 // GT Lighter and GT Paint Sprayer for example
 public class OverlayGadgets extends OverlayDurabilityLike {
@@ -113,45 +115,50 @@ public class OverlayGadgets extends OverlayDurabilityLike {
     public static DurabilityLikeInfo handleGregtech(@NotNull ItemStack stack) {
         long max;
         long current = 0;
-        if (stack.stackSize != 1) return null;
-        var damage = stack.getItemDamage();
-        switch (damage) {
-            case 32472 -> max = 16;
-            case 32473 -> {
-                max = 16;
-                current = max;
-            }
-            case 32474, 32475 -> max = 100;
-            case 32476 -> {
-                max = 100;
-                current = max;
-            }
-            case 32477, 32478 -> max = 1000;
-            case 32479 -> {
-                max = 1000;
-                current = max;
-            }
-            case 32430, 32431, 32432, 32433, 32434, 32435, 32436, 32437, 32438, 32439, 32440, 32441, 32442, 32443, 32444, 32445, 32446, 32447, 32448, 32449, 32450, 32451, 32452, 32453, 32454, 32455, 32456, 32457, 32458, 32459, 32460 -> {
-                max = 512;
-                if (damage % 2 == 0) {
+
+        if (stack.getItem() instanceof GT_MetaGenerated_Item_01) {
+            if (stack.stackSize != 1) return null;
+            var damage = stack.getItemDamage();
+            switch (damage) {
+                case 32472 -> max = 16; // Tool_MatchBox_Used
+                case 32473 -> { // Tool_MatchBox_Full
+                    max = 16;
                     current = max;
                 }
+                case 32474, 32475 -> max = 100; // Tool_Lighter_Invar_Empty, Tool_Lighter_Invar_Used
+                case 32476 -> { // Tool_Lighter_Invar_Full
+                    max = 100;
+                    current = max;
+                }
+                case 32477, 32478 -> max = 1000; // Tool_Lighter_Platinum_Empty, Tool_Lighter_Platinum_Used
+                case 32479 -> { // Tool_Lighter_Platinum_Full
+                    max = 1000;
+                    current = max;
+                }
+                // spray cans
+                case 32430, 32431, 32432, 32433, 32434, 32435, 32436, 32437, 32438, 32439, 32440, 32441, 32442, 32443, 32444, 32445, 32446, 32447, 32448, 32449, 32450, 32451, 32452, 32453, 32454, 32455, 32456, 32457, 32458, 32459, 32460 -> {
+                    max = 512;
+                    if (damage % 2 == 0) {
+                        current = max;
+                    }
+                }
+                default -> {
+                    return null;
+                }
             }
-            default -> {
-                return null;
-            }
-        }
 
-        if (stack.hasTagCompound()) {
-            var tag = stack.getTagCompound();
-            if (tag.hasKey("GT.RemainingPaint")) {
-                current = tag.getLong("GT.RemainingPaint");
+            if (stack.hasTagCompound()) {
+                var tag = stack.getTagCompound();
+                if (tag.hasKey("GT.RemainingPaint")) {
+                    current = tag.getLong("GT.RemainingPaint");
+                }
+                if (tag.hasKey("GT.LighterFuel")) {
+                    current = tag.getLong("GT.LighterFuel");
+                }
             }
-            if (tag.hasKey("GT.LighterFuel")) {
-                current = tag.getLong("GT.LighterFuel");
-
-            }
+            return new DurabilityLikeInfo(current, max);
+        } else {
+            return null;
         }
-        return new DurabilityLikeInfo(current, max);
     }
 }

--- a/src/main/java/com/caedis/duradisplay/overlay/OverlayGadgets.java
+++ b/src/main/java/com/caedis/duradisplay/overlay/OverlayGadgets.java
@@ -139,6 +139,15 @@ public class OverlayGadgets extends OverlayDurabilityLike {
                     current = max;
                 }
             }
+            // spray can remover full
+            case 32465 -> {
+                max = 1024;
+                current = max;
+            }
+            // spray can remover
+            case 32466 -> {
+                max = 1024;
+            }
             default -> {
                 return null;
             }

--- a/src/main/java/com/caedis/duradisplay/overlay/OverlayGadgets.java
+++ b/src/main/java/com/caedis/duradisplay/overlay/OverlayGadgets.java
@@ -14,8 +14,6 @@ import com.caedis.duradisplay.utils.DurabilityFormatter;
 import com.caedis.duradisplay.utils.DurabilityLikeInfo;
 import com.google.common.collect.Sets;
 
-import gregtech.common.items.GT_MetaGenerated_Item_01;
-
 // Gadgets are items to show UseCount(remain) as default
 // GT Lighter and GT Paint Sprayer for example
 public class OverlayGadgets extends OverlayDurabilityLike {
@@ -51,7 +49,7 @@ public class OverlayGadgets extends OverlayDurabilityLike {
                     return "gadgets";
                 }
             });
-        addHandler("gregtech.api.items.GT_MetaBase_Item", OverlayGadgets::handleGregtech);
+        addHandler("gregtech.common.items.GT_MetaGenerated_Item_01", OverlayGadgets::handleGregtechMeta1);
         addHandler("buildcraft.core.ItemPaintbrush", OverlayGadgets::handleBCBrush);
         addHandler("tmechworks.items.SpoolOfWire", OverlayGadgets::handleMechworks);
         addHandler("ic2.core.item.tool.ItemToolPainter", OverlayDurability::handleDefault);
@@ -112,53 +110,49 @@ public class OverlayGadgets extends OverlayDurabilityLike {
     }
 
     @Nullable
-    public static DurabilityLikeInfo handleGregtech(@NotNull ItemStack stack) {
+    public static DurabilityLikeInfo handleGregtechMeta1(@NotNull ItemStack stack) {
         long max;
         long current = 0;
 
-        if (stack.getItem() instanceof GT_MetaGenerated_Item_01) {
-            if (stack.stackSize != 1) return null;
-            var damage = stack.getItemDamage();
-            switch (damage) {
-                case 32472 -> max = 16; // Tool_MatchBox_Used
-                case 32473 -> { // Tool_MatchBox_Full
-                    max = 16;
+        if (stack.stackSize != 1) return null;
+        var damage = stack.getItemDamage();
+        switch (damage) {
+            case 32472 -> max = 16; // Tool_MatchBox_Used
+            case 32473 -> { // Tool_MatchBox_Full
+                max = 16;
+                current = max;
+            }
+            case 32474, 32475 -> max = 100; // Tool_Lighter_Invar_Empty, Tool_Lighter_Invar_Used
+            case 32476 -> { // Tool_Lighter_Invar_Full
+                max = 100;
+                current = max;
+            }
+            case 32477, 32478 -> max = 1000; // Tool_Lighter_Platinum_Empty, Tool_Lighter_Platinum_Used
+            case 32479 -> { // Tool_Lighter_Platinum_Full
+                max = 1000;
+                current = max;
+            }
+            // spray cans
+            case 32430, 32431, 32432, 32433, 32434, 32435, 32436, 32437, 32438, 32439, 32440, 32441, 32442, 32443, 32444, 32445, 32446, 32447, 32448, 32449, 32450, 32451, 32452, 32453, 32454, 32455, 32456, 32457, 32458, 32459, 32460 -> {
+                max = 512;
+                if (damage % 2 == 0) {
                     current = max;
-                }
-                case 32474, 32475 -> max = 100; // Tool_Lighter_Invar_Empty, Tool_Lighter_Invar_Used
-                case 32476 -> { // Tool_Lighter_Invar_Full
-                    max = 100;
-                    current = max;
-                }
-                case 32477, 32478 -> max = 1000; // Tool_Lighter_Platinum_Empty, Tool_Lighter_Platinum_Used
-                case 32479 -> { // Tool_Lighter_Platinum_Full
-                    max = 1000;
-                    current = max;
-                }
-                // spray cans
-                case 32430, 32431, 32432, 32433, 32434, 32435, 32436, 32437, 32438, 32439, 32440, 32441, 32442, 32443, 32444, 32445, 32446, 32447, 32448, 32449, 32450, 32451, 32452, 32453, 32454, 32455, 32456, 32457, 32458, 32459, 32460 -> {
-                    max = 512;
-                    if (damage % 2 == 0) {
-                        current = max;
-                    }
-                }
-                default -> {
-                    return null;
                 }
             }
-
-            if (stack.hasTagCompound()) {
-                var tag = stack.getTagCompound();
-                if (tag.hasKey("GT.RemainingPaint")) {
-                    current = tag.getLong("GT.RemainingPaint");
-                }
-                if (tag.hasKey("GT.LighterFuel")) {
-                    current = tag.getLong("GT.LighterFuel");
-                }
+            default -> {
+                return null;
             }
-            return new DurabilityLikeInfo(current, max);
-        } else {
-            return null;
         }
+
+        if (stack.hasTagCompound()) {
+            var tag = stack.getTagCompound();
+            if (tag.hasKey("GT.RemainingPaint")) {
+                current = tag.getLong("GT.RemainingPaint");
+            }
+            if (tag.hasKey("GT.LighterFuel")) {
+                current = tag.getLong("GT.LighterFuel");
+            }
+        }
+        return new DurabilityLikeInfo(current, max);
     }
 }


### PR DESCRIPTION
Fixes an issue when an item has the same metadata from another metaitem (planks matched the lighter funny enough)