### PR TITLE
Adds a custom overlay for Forestry backpacks

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -44,4 +44,5 @@ dependencies {
     compileOnly("com.github.GTNewHorizons:Botania:1.11.5-GTNH:dev")
     compileOnly("com.github.GTNewHorizons:TinkersConstruct:1.12.8-GTNH:dev")
     compileOnly("com.github.GTNewHorizons:TinkersMechworks:0.3.1:dev")
+    compileOnly("com.github.GTNewHorizons:ForestryMC:4.9.10:dev")
 }

--- a/src/main/java/com/caedis/duradisplay/overlay/OverlayContainer.java
+++ b/src/main/java/com/caedis/duradisplay/overlay/OverlayContainer.java
@@ -1,0 +1,92 @@
+package com.caedis.duradisplay.overlay;
+
+import net.minecraft.item.ItemStack;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.caedis.duradisplay.config.ConfigDurabilityLike;
+import com.caedis.duradisplay.config.DuraDisplayConfig;
+import com.caedis.duradisplay.utils.ColorType;
+import com.caedis.duradisplay.utils.DurabilityFormatter;
+import com.caedis.duradisplay.utils.DurabilityLikeInfo;
+import com.caedis.duradisplay.utils.ModSelfDrawnBar;
+
+import forestry.core.inventory.ItemInventory;
+import forestry.storage.items.ItemBackpack;
+
+@SuppressWarnings("unused")
+public class OverlayContainer extends OverlayDurabilityLike {
+
+    private static boolean showFullness = false;
+
+    public OverlayContainer() {
+        super(new ConfigContainer());
+        addHandler("forestry.storage.items.ItemBackpack", OverlayContainer::handleForestryBackpack);
+    }
+
+    public static DurabilityLikeInfo handleForestryBackpack(@NotNull ItemStack stack) {
+        ItemBackpack backpack = (ItemBackpack) stack.getItem();
+        assert backpack != null;
+
+        final int backpackSize = backpack.getBackpackSize();
+        final int used = ItemInventory.getOccupiedSlotCount(stack);
+        final int remaining = backpackSize - used;
+        if (showFullness) {
+            return new DurabilityLikeInfo(used, backpackSize);
+        } else {
+            return new DurabilityLikeInfo(remaining, backpackSize);
+        }
+
+    }
+
+    @Override
+    @NotNull
+    ConfigDurabilityLike config() {
+        return config;
+    }
+
+    private static class ConfigContainer extends ConfigDurabilityLike {
+
+        public ConfigContainer() {
+            super(
+                true,
+                Style.Text,
+                DurabilityFormatter.Format.container,
+                2,
+                false,
+                true,
+                0x00FF00,
+                ColorType.RYGDurability,
+                new double[] { 30, 70 },
+                new int[] { 0xFF0000, 0x55FF00, 0x00FF00 },
+                true,
+                0,
+                true);
+        }
+
+        @Override
+        public void loadConfig() {
+            super.loadConfig();
+
+            showFullness = config.getBoolean(
+                "ShowFullness",
+                category(),
+                false,
+                "Makes containers show how many slots are taken on true, how many slots are remaining when false");
+        }
+
+        @Override
+        public void postLoadConfig() {
+            if (enabled && DuraDisplayConfig.Enable) ModSelfDrawnBar.changeDurabilitybar(false);
+            else ModSelfDrawnBar.restoreDurabilitybar();
+            configCategory.setComment("""
+                Container shows slots used out of remaining
+                                                                """);
+        }
+
+        @Override
+        public @NotNull String category() {
+            return "container";
+        }
+    }
+}

--- a/src/main/java/com/caedis/duradisplay/utils/DurabilityFormatter.java
+++ b/src/main/java/com/caedis/duradisplay/utils/DurabilityFormatter.java
@@ -12,6 +12,7 @@ public class DurabilityFormatter {
         used,
         max,
         fraction,
+        container,
     }
 
     @Nullable
@@ -32,6 +33,17 @@ public class DurabilityFormatter {
             }
             case fraction -> {
                 return Double.isNaN(percent) ? null : String.format("%.0f/%.0f", current, max);
+            }
+            case container -> {
+                final long maxLong = Math.round(max);
+                final long currentLong = Math.round(current);
+                if (maxLong >= 100) {
+                    if (currentLong >= 1000) {
+                        return "*";
+                    }
+                    return String.format("%d", currentLong);
+                }
+                return String.format("%d/%d", currentLong, maxLong);
             }
         }
         return null;


### PR DESCRIPTION
This PR adds a custom overlay for Forestry backpacks to show how many slots are left. This is related to the Forestry PR at https://github.com/GTNewHorizons/ForestryMC/pull/101 , but they aren't dependent on each other; they can both be merged independently of each other.

To implement this, `OverlayContainer` was added. It allows for a `X/Y` style text display to be used. It has some basic protections against very large containers. Currently only Forestry backpacks are supported, but other inventory containers could be implemented if the desire is there.

By default, `OverlayContainer` shows remaining stacks out of total, but the `ShowFullness` switch in the config can change this to stacks used out of total. This doesn't adjust the color or "show full"/"show empty" logic, but users can adjust this in the config to their tastes.

## Media

<img width="1789" height="1019" alt="java_V6Roey0yXx" src="https://github.com/user-attachments/assets/0e06711d-a9dd-4efa-985d-55dbf3c62152" />

https://github.com/user-attachments/assets/580929c4-bc5b-4024-af3f-0c8dcc944697

