### PR TITLE
Made certain dependencies optional to prevent crashes when running outside GTNH

### DIFF
--- a/src/main/java/com/caedis/duradisplay/overlay/OverlayCharge.java
+++ b/src/main/java/com/caedis/duradisplay/overlay/OverlayCharge.java
@@ -10,9 +10,9 @@ import com.caedis.duradisplay.utils.ColorType;
 import com.caedis.duradisplay.utils.DurabilityFormatter;
 import com.caedis.duradisplay.utils.DurabilityLikeInfo;
 import com.caedis.duradisplay.utils.ModSelfDrawnBar;
+import com.caedis.duradisplay.utils.Mods;
 
 import cofh.api.energy.IEnergyContainerItem;
-import cpw.mods.fml.common.Loader;
 import ic2.api.item.ElectricItem;
 import ic2.api.item.IElectricItem;
 
@@ -50,10 +50,10 @@ public class OverlayCharge extends OverlayDurabilityLike {
                     return "charge";
                 }
             });
-        if (Loader.isModLoaded("IC2")) addHandler("ic2.api.item.IElectricItem", OverlayCharge::handleIElectricItem);
-        if (Loader.isModLoaded("TConstruct"))
+        if (Mods.IC2.isLoaded()) addHandler("ic2.api.item.IElectricItem", OverlayCharge::handleIElectricItem);
+        if (Mods.TinkersConstruct.isLoaded())
             addHandler("tconstruct.library.tools.ToolCore", OverlayCharge::handleToolCore);
-        if (Loader.isModLoaded("CoFHCore"))
+        if (Mods.CofhCore.isLoaded())
             addHandler("cofh.api.energy.IEnergyContainerItem", OverlayCharge::handleEnergyContainer);
     }
 

--- a/src/main/java/com/caedis/duradisplay/overlay/OverlayCharge.java
+++ b/src/main/java/com/caedis/duradisplay/overlay/OverlayCharge.java
@@ -12,6 +12,7 @@ import com.caedis.duradisplay.utils.DurabilityLikeInfo;
 import com.caedis.duradisplay.utils.ModSelfDrawnBar;
 
 import cofh.api.energy.IEnergyContainerItem;
+import cpw.mods.fml.common.Loader;
 import ic2.api.item.ElectricItem;
 import ic2.api.item.IElectricItem;
 
@@ -49,9 +50,11 @@ public class OverlayCharge extends OverlayDurabilityLike {
                     return "charge";
                 }
             });
-        addHandler("ic2.api.item.IElectricItem", OverlayCharge::handleIElectricItem);
-        addHandler("tconstruct.library.tools.ToolCore", OverlayCharge::handleToolCore);
-        addHandler("cofh.api.energy.IEnergyContainerItem", OverlayCharge::handleEnergyContainer);
+        if (Loader.isModLoaded("IC2")) addHandler("ic2.api.item.IElectricItem", OverlayCharge::handleIElectricItem);
+        if (Loader.isModLoaded("TConstruct"))
+            addHandler("tconstruct.library.tools.ToolCore", OverlayCharge::handleToolCore);
+        if (Loader.isModLoaded("CoFHCore"))
+            addHandler("cofh.api.energy.IEnergyContainerItem", OverlayCharge::handleEnergyContainer);
     }
 
     @Override

--- a/src/main/java/com/caedis/duradisplay/overlay/OverlayContainer.java
+++ b/src/main/java/com/caedis/duradisplay/overlay/OverlayContainer.java
@@ -10,8 +10,8 @@ import com.caedis.duradisplay.utils.ColorType;
 import com.caedis.duradisplay.utils.DurabilityFormatter;
 import com.caedis.duradisplay.utils.DurabilityLikeInfo;
 import com.caedis.duradisplay.utils.ModSelfDrawnBar;
+import com.caedis.duradisplay.utils.Mods;
 
-import cpw.mods.fml.common.Loader;
 import forestry.core.inventory.ItemInventory;
 import forestry.storage.items.ItemBackpack;
 
@@ -22,7 +22,7 @@ public class OverlayContainer extends OverlayDurabilityLike {
 
     public OverlayContainer() {
         super(new ConfigContainer());
-        if (Loader.isModLoaded("Forestry"))
+        if (Mods.Forestry.isLoaded())
             addHandler("forestry.storage.items.ItemBackpack", OverlayContainer::handleForestryBackpack);
     }
 

--- a/src/main/java/com/caedis/duradisplay/overlay/OverlayContainer.java
+++ b/src/main/java/com/caedis/duradisplay/overlay/OverlayContainer.java
@@ -11,6 +11,7 @@ import com.caedis.duradisplay.utils.DurabilityFormatter;
 import com.caedis.duradisplay.utils.DurabilityLikeInfo;
 import com.caedis.duradisplay.utils.ModSelfDrawnBar;
 
+import cpw.mods.fml.common.Loader;
 import forestry.core.inventory.ItemInventory;
 import forestry.storage.items.ItemBackpack;
 
@@ -21,7 +22,8 @@ public class OverlayContainer extends OverlayDurabilityLike {
 
     public OverlayContainer() {
         super(new ConfigContainer());
-        addHandler("forestry.storage.items.ItemBackpack", OverlayContainer::handleForestryBackpack);
+        if (Loader.isModLoaded("Forestry"))
+            addHandler("forestry.storage.items.ItemBackpack", OverlayContainer::handleForestryBackpack);
     }
 
     public static DurabilityLikeInfo handleForestryBackpack(@NotNull ItemStack stack) {

--- a/src/main/java/com/caedis/duradisplay/overlay/OverlayDurability.java
+++ b/src/main/java/com/caedis/duradisplay/overlay/OverlayDurability.java
@@ -13,6 +13,7 @@ import com.caedis.duradisplay.utils.DurabilityFormatter;
 import com.caedis.duradisplay.utils.DurabilityLikeInfo;
 import com.caedis.duradisplay.utils.ModSelfDrawnBar;
 
+import cpw.mods.fml.common.Loader;
 import gregtech.api.items.ItemRadioactiveCell;
 import ic2.api.item.ICustomDamageItem;
 import ic2.core.item.armor.ItemArmorFluidTank;
@@ -50,20 +51,38 @@ public class OverlayDurability extends OverlayDurabilityLike {
                     return "durability";
                 }
             });
-        addHandler("gregtech.api.items.MetaBaseItem", OverlayDurability::handleGregTech);
-        addHandler("gregtech.api.items.ItemRadioactiveCell", OverlayDurability::handleGregTechRadioactiveCell);
-        addHandler("tconstruct.library.weaponry.AmmoItem", i -> null);
-        addHandler("appeng.items.tools.powered.powersink.AEBasePoweredItem", i -> null);
-        addHandler("ic2.api.item.IElectricItem", i -> null);
-        addHandler("tconstruct.library.tools.ToolCore", OverlayDurability::handleToolCore);
-        addHandler("ic2.core.item.armor.ItemArmorFluidTank", OverlayDurability::handleItemArmorFluidTank);
-        addHandler("ic2.api.item.ICustomDamageItem", OverlayDurability::handleICustomDamageItem);
-        addHandler("vazkii.botania.common.item.brew.ItemBrewBase", i -> null);
-        addHandler("WayofTime.alchemicalWizardry.common.items.potion.AlchemyFlask", i -> null);
-        addHandler("WayofTime.alchemicalWizardry.common.items.ScribeTool", i -> null);
-        addHandler("buildcraft.core.ItemPaintbrush", i -> null);
-        addHandler("ic2.core.item.tool.ItemToolPainter", i -> null);
-        addHandler("thaumcraft.api.IScribeTools", i -> null);
+
+        if (Loader.isModLoaded("gregtech")) {
+            addHandler("gregtech.api.items.MetaBaseItem", OverlayDurability::handleGregTech);
+            addHandler("gregtech.api.items.ItemRadioactiveCell", OverlayDurability::handleGregTechRadioactiveCell);
+        }
+
+        if (Loader.isModLoaded("TConstruct")) {
+            addHandler("tconstruct.library.weaponry.AmmoItem", i -> null);
+            addHandler("tconstruct.library.tools.ToolCore", OverlayDurability::handleToolCore);
+        }
+
+        if (Loader.isModLoaded("appliedenergistics2"))
+            addHandler("appeng.items.tools.powered.powersink.AEBasePoweredItem", i -> null);
+
+        if (Loader.isModLoaded("IC2")) {
+            addHandler("ic2.api.item.IElectricItem", i -> null);
+            addHandler("ic2.core.item.armor.ItemArmorFluidTank", OverlayDurability::handleItemArmorFluidTank);
+            addHandler("ic2.api.item.ICustomDamageItem", OverlayDurability::handleICustomDamageItem);
+            addHandler("ic2.core.item.tool.ItemToolPainter", i -> null);
+        }
+
+        if (Loader.isModLoaded("Botania")) addHandler("vazkii.botania.common.item.brew.ItemBrewBase", i -> null);
+
+        if (Loader.isModLoaded("AWWayofTime")) {
+            addHandler("WayofTime.alchemicalWizardry.common.items.potion.AlchemyFlask", i -> null);
+            addHandler("WayofTime.alchemicalWizardry.common.items.ScribeTool", i -> null);
+        }
+
+        if (Loader.isModLoaded("BuildCraft|Core")) addHandler("buildcraft.core.ItemPaintbrush", i -> null);
+
+        if (Loader.isModLoaded("Thaumcraft")) addHandler("thaumcraft.api.IScribeTools", i -> null);
+
         addHandler("net.minecraft.item.Item", OverlayDurability::handleDefault);
     }
 

--- a/src/main/java/com/caedis/duradisplay/overlay/OverlayDurability.java
+++ b/src/main/java/com/caedis/duradisplay/overlay/OverlayDurability.java
@@ -12,8 +12,8 @@ import com.caedis.duradisplay.utils.ColorType;
 import com.caedis.duradisplay.utils.DurabilityFormatter;
 import com.caedis.duradisplay.utils.DurabilityLikeInfo;
 import com.caedis.duradisplay.utils.ModSelfDrawnBar;
+import com.caedis.duradisplay.utils.Mods;
 
-import cpw.mods.fml.common.Loader;
 import gregtech.api.items.ItemRadioactiveCell;
 import ic2.api.item.ICustomDamageItem;
 import ic2.core.item.armor.ItemArmorFluidTank;
@@ -52,36 +52,35 @@ public class OverlayDurability extends OverlayDurabilityLike {
                 }
             });
 
-        if (Loader.isModLoaded("gregtech")) {
+        if (Mods.GregTech.isLoaded()) {
             addHandler("gregtech.api.items.MetaBaseItem", OverlayDurability::handleGregTech);
             addHandler("gregtech.api.items.ItemRadioactiveCell", OverlayDurability::handleGregTechRadioactiveCell);
         }
 
-        if (Loader.isModLoaded("TConstruct")) {
+        if (Mods.TinkersConstruct.isLoaded()) {
             addHandler("tconstruct.library.weaponry.AmmoItem", i -> null);
             addHandler("tconstruct.library.tools.ToolCore", OverlayDurability::handleToolCore);
         }
 
-        if (Loader.isModLoaded("appliedenergistics2"))
-            addHandler("appeng.items.tools.powered.powersink.AEBasePoweredItem", i -> null);
+        if (Mods.AE2.isLoaded()) addHandler("appeng.items.tools.powered.powersink.AEBasePoweredItem", i -> null);
 
-        if (Loader.isModLoaded("IC2")) {
+        if (Mods.IC2.isLoaded()) {
             addHandler("ic2.api.item.IElectricItem", i -> null);
             addHandler("ic2.core.item.armor.ItemArmorFluidTank", OverlayDurability::handleItemArmorFluidTank);
             addHandler("ic2.api.item.ICustomDamageItem", OverlayDurability::handleICustomDamageItem);
             addHandler("ic2.core.item.tool.ItemToolPainter", i -> null);
         }
 
-        if (Loader.isModLoaded("Botania")) addHandler("vazkii.botania.common.item.brew.ItemBrewBase", i -> null);
+        if (Mods.Botania.isLoaded()) addHandler("vazkii.botania.common.item.brew.ItemBrewBase", i -> null);
 
-        if (Loader.isModLoaded("AWWayofTime")) {
+        if (Mods.AlchemicalWizardry.isLoaded()) {
             addHandler("WayofTime.alchemicalWizardry.common.items.potion.AlchemyFlask", i -> null);
             addHandler("WayofTime.alchemicalWizardry.common.items.ScribeTool", i -> null);
         }
 
-        if (Loader.isModLoaded("BuildCraft|Core")) addHandler("buildcraft.core.ItemPaintbrush", i -> null);
+        if (Mods.BuildCraftCore.isLoaded()) addHandler("buildcraft.core.ItemPaintbrush", i -> null);
 
-        if (Loader.isModLoaded("Thaumcraft")) addHandler("thaumcraft.api.IScribeTools", i -> null);
+        if (Mods.Thaumcraft.isLoaded()) addHandler("thaumcraft.api.IScribeTools", i -> null);
 
         addHandler("net.minecraft.item.Item", OverlayDurability::handleDefault);
     }

--- a/src/main/java/com/caedis/duradisplay/overlay/OverlayGadgets.java
+++ b/src/main/java/com/caedis/duradisplay/overlay/OverlayGadgets.java
@@ -14,6 +14,8 @@ import com.caedis.duradisplay.utils.DurabilityFormatter;
 import com.caedis.duradisplay.utils.DurabilityLikeInfo;
 import com.google.common.collect.Sets;
 
+import cpw.mods.fml.common.Loader;
+
 // Gadgets are items to show UseCount(remain) as default
 // GT Lighter and GT Paint Sprayer for example
 public class OverlayGadgets extends OverlayDurabilityLike {
@@ -49,12 +51,25 @@ public class OverlayGadgets extends OverlayDurabilityLike {
                     return "gadgets";
                 }
             });
-        addHandler("gregtech.common.items.MetaGeneratedItem01", OverlayGadgets::handleGregtechMeta1);
-        addHandler("buildcraft.core.ItemPaintbrush", OverlayGadgets::handleBCBrush);
-        addHandler("tmechworks.items.SpoolOfWire", OverlayGadgets::handleMechworks);
-        addHandler("ic2.core.item.tool.ItemToolPainter", OverlayDurability::handleDefault);
-        addHandler("WayofTime.alchemicalWizardry.common.items.ScribeTool", OverlayDurability::handleDefault);
-        addHandler("thaumcraft.api.IScribeTools", OverlayDurability::handleDefault);
+
+        if (Loader.isModLoaded("gregtech"))
+            addHandler("gregtech.common.items.MetaGeneratedItem01", OverlayGadgets::handleGregtechMeta1);
+
+        if (Loader.isModLoaded("BuildCraft|Core"))
+            addHandler("buildcraft.core.ItemPaintbrush", OverlayGadgets::handleBCBrush);
+
+        if (Loader.isModLoaded("TMechworks"))
+            addHandler("tmechworks.items.SpoolOfWire", OverlayGadgets::handleMechworks);
+
+        if (Loader.isModLoaded("IC2"))
+            addHandler("ic2.core.item.tool.ItemToolPainter", OverlayDurability::handleDefault);
+
+        if (Loader.isModLoaded("AWWayofTime"))
+            addHandler("WayofTime.alchemicalWizardry.common.items.ScribeTool", OverlayDurability::handleDefault);
+
+        if (Loader.isModLoaded("Thaumcraft"))
+            addHandler("thaumcraft.api.IScribeTools", OverlayDurability::handleDefault);
+
         addHandler("net.minecraft.item.Item", OverlayGadgets::handleByAllowList);
     }
 

--- a/src/main/java/com/caedis/duradisplay/overlay/OverlayGadgets.java
+++ b/src/main/java/com/caedis/duradisplay/overlay/OverlayGadgets.java
@@ -12,9 +12,8 @@ import com.caedis.duradisplay.config.ConfigDurabilityLike;
 import com.caedis.duradisplay.utils.ColorType;
 import com.caedis.duradisplay.utils.DurabilityFormatter;
 import com.caedis.duradisplay.utils.DurabilityLikeInfo;
+import com.caedis.duradisplay.utils.Mods;
 import com.google.common.collect.Sets;
-
-import cpw.mods.fml.common.Loader;
 
 // Gadgets are items to show UseCount(remain) as default
 // GT Lighter and GT Paint Sprayer for example
@@ -52,23 +51,20 @@ public class OverlayGadgets extends OverlayDurabilityLike {
                 }
             });
 
-        if (Loader.isModLoaded("gregtech"))
+        if (Mods.GregTech.isLoaded())
             addHandler("gregtech.common.items.MetaGeneratedItem01", OverlayGadgets::handleGregtechMeta1);
 
-        if (Loader.isModLoaded("BuildCraft|Core"))
-            addHandler("buildcraft.core.ItemPaintbrush", OverlayGadgets::handleBCBrush);
+        if (Mods.BuildCraftCore.isLoaded()) addHandler("buildcraft.core.ItemPaintbrush", OverlayGadgets::handleBCBrush);
 
-        if (Loader.isModLoaded("TMechworks"))
+        if (Mods.TinkersMechworks.isLoaded())
             addHandler("tmechworks.items.SpoolOfWire", OverlayGadgets::handleMechworks);
 
-        if (Loader.isModLoaded("IC2"))
-            addHandler("ic2.core.item.tool.ItemToolPainter", OverlayDurability::handleDefault);
+        if (Mods.IC2.isLoaded()) addHandler("ic2.core.item.tool.ItemToolPainter", OverlayDurability::handleDefault);
 
-        if (Loader.isModLoaded("AWWayofTime"))
+        if (Mods.AlchemicalWizardry.isLoaded())
             addHandler("WayofTime.alchemicalWizardry.common.items.ScribeTool", OverlayDurability::handleDefault);
 
-        if (Loader.isModLoaded("Thaumcraft"))
-            addHandler("thaumcraft.api.IScribeTools", OverlayDurability::handleDefault);
+        if (Mods.Thaumcraft.isLoaded()) addHandler("thaumcraft.api.IScribeTools", OverlayDurability::handleDefault);
 
         addHandler("net.minecraft.item.Item", OverlayGadgets::handleByAllowList);
     }

--- a/src/main/java/com/caedis/duradisplay/overlay/OverlayPotionBrew.java
+++ b/src/main/java/com/caedis/duradisplay/overlay/OverlayPotionBrew.java
@@ -8,8 +8,8 @@ import com.caedis.duradisplay.config.ConfigDurabilityLike;
 import com.caedis.duradisplay.utils.ColorType;
 import com.caedis.duradisplay.utils.DurabilityFormatter;
 import com.caedis.duradisplay.utils.DurabilityLikeInfo;
+import com.caedis.duradisplay.utils.Mods;
 
-import cpw.mods.fml.common.Loader;
 import vazkii.botania.common.item.brew.ItemBrewBase;
 
 // Overlay for brew and potions
@@ -49,10 +49,10 @@ public class OverlayPotionBrew extends OverlayDurabilityLike {
                 }
             });
 
-        if (Loader.isModLoaded("Botania"))
+        if (Mods.Botania.isLoaded())
             addHandler("vazkii.botania.common.item.brew.ItemBrewBase", OverlayPotionBrew::handleBotaniaBrew);
 
-        if (Loader.isModLoaded("AWWayofTime")) addHandler(
+        if (Mods.AlchemicalWizardry.isLoaded()) addHandler(
             "WayofTime.alchemicalWizardry.common.items.potion.AlchemyFlask",
             OverlayDurability::handleDefault);
 

--- a/src/main/java/com/caedis/duradisplay/overlay/OverlayPotionBrew.java
+++ b/src/main/java/com/caedis/duradisplay/overlay/OverlayPotionBrew.java
@@ -9,6 +9,7 @@ import com.caedis.duradisplay.utils.ColorType;
 import com.caedis.duradisplay.utils.DurabilityFormatter;
 import com.caedis.duradisplay.utils.DurabilityLikeInfo;
 
+import cpw.mods.fml.common.Loader;
 import vazkii.botania.common.item.brew.ItemBrewBase;
 
 // Overlay for brew and potions
@@ -47,8 +48,13 @@ public class OverlayPotionBrew extends OverlayDurabilityLike {
                     return "potion_brew";
                 }
             });
-        addHandler("vazkii.botania.common.item.brew.ItemBrewBase", OverlayPotionBrew::handleBotaniaBrew);
-        addHandler("WayofTime.alchemicalWizardry.common.items.potion.AlchemyFlask", OverlayDurability::handleDefault);
+
+        if (Loader.isModLoaded("Botania"))
+            addHandler("vazkii.botania.common.item.brew.ItemBrewBase", OverlayPotionBrew::handleBotaniaBrew);
+
+        if (Loader.isModLoaded("AWWayofTime")) addHandler(
+            "WayofTime.alchemicalWizardry.common.items.potion.AlchemyFlask",
+            OverlayDurability::handleDefault);
 
     }
 

--- a/src/main/java/com/caedis/duradisplay/utils/Mods.java
+++ b/src/main/java/com/caedis/duradisplay/utils/Mods.java
@@ -1,0 +1,48 @@
+package com.caedis.duradisplay.utils;
+
+import java.util.function.Supplier;
+
+import cpw.mods.fml.common.Loader;
+
+public enum Mods {
+
+    // spotless:off
+    AE2("appliedenergistics2"),
+    AlchemicalWizardry("AWWayofTime"),
+    Botania("Botania"),
+    BuildCraftCore("BuildCraft|Core"),
+    CofhCore("CoFHCore"),
+    Forestry("Forestry"),
+    GregTech("gregtech"),
+    IC2("IC2"),
+    Thaumcraft("Thaumcraft"),
+    TinkersConstruct("TConstruct"),
+    TinkersMechworks("TMechworks")
+    ;
+    // spotless:on
+
+    public final String modid;
+    private final Supplier<Boolean> supplier;
+    private Boolean loaded;
+
+    Mods(String modid) {
+        this.modid = modid;
+        this.supplier = null;
+    }
+
+    Mods(Supplier<Boolean> supplier) {
+        this.supplier = supplier;
+        this.modid = null;
+    }
+
+    public boolean isLoaded() {
+        if (loaded == null) {
+            if (supplier != null) {
+                loaded = supplier.get();
+            } else if (modid != null) {
+                loaded = Loader.isModLoaded(modid);
+            } else loaded = false;
+        }
+        return loaded;
+    }
+}


### PR DESCRIPTION
Summary :
This patch prevents DuraDisplay from crashing the game when running outside of GTNH. The crash occured because IndustrialCraft² was not present. The mod tried to load IC2 classes unconditionally.
Other optional dependencies could also trigger similar crashes, so this patch makes those integrations properly optional.

Details :
DuraDisplay previously referenced IC2 classes directly without checking if IC2 is installed : 
`ic2.api.item.ElectricItem
ic2.api.item.IElectricItem
`
The patch ensure checks are done before adding handler to those mods.


Crash Log :
`java.lang.NoClassDefFoundError: ic2/api/item/ElectricItem at com.caedis.duradisplay.overlay.OverlayCharge.handleIElectricItem(OverlayCharge.java:67) at com.caedis.duradisplay.overlay.OverlayCharge$$Lambda$1509/1130611319.apply(Unknown Source) at com.caedis.duradisplay.overlay.OverlayDurabilityLike.getDurabilityLikeInfo(OverlayDurabilityLike.java:61) at com.caedis.duradisplay.overlay.OverlayDurabilityLike.getRenderer(OverlayDurabilityLike.java:82) at com.caedis.duradisplay.render.DurabilityRenderer.Render(DurabilityRenderer.java:35) at net.minecraft.client.renderer.entity.RenderItem.redirect$zbl000$duradisplay$showDurabilityBar(RenderItem.java:876) at net.minecraft.client.renderer.entity.RenderItem.func_94148_a(RenderItem.java:691) at codechicken.nei.guihook.GuiContainerManager.lambda$drawItem$0(GuiContainerManager.java:351) at codechicken.nei.guihook.GuiContainerManager$$Lambda$2428/834777809.run(Unknown Source) at codechicken.nei.guihook.GuiContainerManager.safeItemRenderContext(GuiContainerManager.java:380) at codechicken.nei.guihook.GuiContainerManager.drawItem(GuiContainerManager.java:318) at codechicken.nei.guihook.GuiContainerManager.drawItem(GuiContainerManager.java:304) at codechicken.nei.ItemsGrid$ItemsGridSlot.drawItem(ItemsGrid.java:179) at codechicken.nei.ItemsGrid$ItemsGridSlot.drawItem(ItemsGrid.java:164) at codechicken.nei.ItemsPanelGrid$ItemsPanelGridSlot.drawItem(ItemsPanelGrid.java:66) at codechicken.nei.ItemsGrid.drawItems(ItemsGrid.java:505) at codechicken.nei.ItemsGrid.draw(ItemsGrid.java:541) at codechicken.nei.ItemsPanelGrid.draw(ItemsPanelGrid.java:243) at codechicken.nei.PanelWidget.draw(PanelWidget.java:158) at codechicken.nei.LayoutManager.renderObjects(LayoutManager.java:278) at codechicken.nei.guihook.GuiContainerManager.renderObjects(GuiContainerManager.java:571) at net.minecraft.client.gui.inventory.GuiContainer.func_73863_a(GuiContainer.java:120) at net.minecraft.client.renderer.InventoryEffectRenderer.func_73863_a(InventoryEffectRenderer.java:1536) at net.minecraft.client.gui.inventory.GuiContainerCreative.func_73863_a(GuiContainerCreative.java:638) at net.minecraft.client.renderer.EntityRenderer.func_78480_b(EntityRenderer.java:1061) at net.minecraft.client.Minecraft.func_71411_J(Minecraft.java:1001) at net.minecraft.client.Minecraft.func_99999_d(Minecraft.java:898) at net.minecraft.client.main.Main.main(SourceFile:148) at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) at java.lang.reflect.Method.invoke(Method.java:497) at net.minecraft.launchwrapper.Launch.launch(Launch.java:135) at net.minecraft.launchwrapper.Launch.main(Launch.java:28) at org.prismlauncher.launcher.impl.StandardLauncher.launch(StandardLauncher.java:105) at org.prismlauncher.EntryPoint.listen(EntryPoint.java:129) at org.prismlauncher.EntryPoint.main(EntryPoint.java:70) Caused by: java.lang.ClassNotFoundException: ic2.api.item.ElectricItem at net.minecraft.launchwrapper.LaunchClassLoader.findClass(LaunchClassLoader.java:191) at java.lang.ClassLoader.loadClass(ClassLoader.java:424) at java.lang.ClassLoader.loadClass(ClassLoader.java:357) ... 37 more Caused by: java.lang.NullPointerException
A detailed walkthrough of the error, its code path and all known details is as follows:
-- Head -- Stacktrace: at com.caedis.duradisplay.overlay.OverlayCharge.handleIElectricItem(OverlayCharge.java:67) at com.caedis.duradisplay.overlay.OverlayCharge$$Lambda$1509/1130611319.apply(Unknown Source) at com.caedis.duradisplay.overlay.OverlayDurabilityLike.getDurabilityLikeInfo(OverlayDurabilityLike.java:61) at com.caedis.duradisplay.overlay.OverlayDurabilityLike.getRenderer(OverlayDurabilityLike.java:82) at com.caedis.duradisplay.render.DurabilityRenderer.Render(DurabilityRenderer.java:35) at net.minecraft.client.renderer.entity.RenderItem.redirect$zbl000$duradisplay$showDurabilityBar(RenderItem.java:876) at net.minecraft.client.renderer.entity.RenderItem.func_94148_a(RenderItem.java:691) at codechicken.nei.guihook.GuiContainerManager.lambda$drawItem$0(GuiContainerManager.java:351) at codechicken.nei.guihook.GuiContainerManager$$Lambda$2428/834777809.run(Unknown Source) at codechicken.nei.guihook.GuiContainerManager.safeItemRenderContext(GuiContainerManager.java:380) at codechicken.nei.guihook.GuiContainerManager.drawItem(GuiContainerManager.java:318) at codechicken.nei.guihook.GuiContainerManager.drawItem(GuiContainerManager.java:304) at codechicken.nei.ItemsGrid$ItemsGridSlot.drawItem(ItemsGrid.java:179) at codechicken.nei.ItemsGrid$ItemsGridSlot.drawItem(ItemsGrid.java:164) at codechicken.nei.ItemsPanelGrid$ItemsPanelGridSlot.drawItem(ItemsPanelGrid.java:66) at codechicken.nei.ItemsGrid.drawItems(ItemsGrid.java:505) at codechicken.nei.ItemsGrid.draw(ItemsGrid.java:541) at codechicken.nei.ItemsPanelGrid.draw(ItemsPanelGrid.java:243) at codechicken.nei.PanelWidget.draw(PanelWidget.java:158) at codechicken.nei.LayoutManager.renderObjects(LayoutManager.java:278) at codechicken.nei.guihook.GuiContainerManager.renderObjects(GuiContainerManager.java:571) at net.minecraft.client.gui.inventory.GuiContainer.func_73863_a(GuiContainer.java:120) at net.minecraft.client.renderer.InventoryEffectRenderer.func_73863_a(InventoryEffectRenderer.java:1536) at net.minecraft.client.gui.inventory.GuiContainerCreative.func_73863_a(GuiContainerCreative.java:638) at net.minecraft.client.renderer.EntityRenderer.func_78480_b(EntityRenderer.java:1061)
`

Impact : 
- Fixes crashes when running DuraDisplay outside of GTNH
- Makes IC2 and other integrations optional
- No behavior changes for GTNH users