### PR TITLE
Make config enum parsing case-insensitive

### DIFF
--- a/src/main/java/com/caedis/duradisplay/utils/ConfigLoad.java
+++ b/src/main/java/com/caedis/duradisplay/utils/ConfigLoad.java
@@ -12,17 +12,25 @@ public class ConfigLoad {
         String comment) {
 
         Class<T> enumType = defaultValue.getDeclaringClass();
-        return T.valueOf(
-            enumType,
-            config.getString(
-                name,
-                category,
-                defaultValue.toString(),
-                comment,
-                Arrays.stream(enumType.getEnumConstants())
-                    .map(Enum::toString)
-                    .toArray(String[]::new)));
+        String value = config.getString(
+            name,
+            category,
+            defaultValue.toString(),
+            comment,
+            Arrays.stream(enumType.getEnumConstants())
+                .map(Enum::toString)
+                .toArray(String[]::new));
 
+        // Match case-insensitively and fall back to the default instead of throwing.
+        for (T constant : enumType.getEnumConstants()) {
+            if (constant.name()
+                .equalsIgnoreCase(value)
+                || constant.toString()
+                    .equalsIgnoreCase(value)) {
+                return constant;
+            }
+        }
+        return defaultValue;
     }
 
     public static <T extends Enum<T>> T loadEnum(String category, String name, T defaultValue, String comment) {


### PR DESCRIPTION
I ran into an issue where config files are rewritten at startup (I still can't understand why), replacing uppercase to lowercase and crashing the client.
I couldn't reproduce on dailies that are downloaded and imported directly on prism, but only on instances that are updated manually by replacing mods and config folder.

This fixes the issue even if the variables in .cfg are lowercase.

related: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/pull/25564